### PR TITLE
fix: default to true when parsing and replacing values in payload json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ or
     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
 
-> To keep the payload json file as is, without replacing values from `github.context`, pass an additional parameter `payload-file-path-parsed`
+> To send the payload file JSON as is, without replacing templated values with
+> `github.context` or `github.env`, set `payload-file-path-parsed` to `false`.
+> Default: `true`.
 
 ```yaml
 - name: Send custom JSON data to Slack workflow
@@ -84,7 +86,7 @@ or
   uses: slackapi/slack-github-action@v1.25.0
   with:
     payload-file-path: "./payload-slack-content.json"
-    payload-file-path-parsed: 'true'
+    payload-file-path-parsed: false
   env:
     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,9 @@ inputs:
     description: 'path to JSON payload to send to Slack if webhook route. If not supplied, json from GitHub event will be sent instead. If payload is provided, it will take preference over this field'
     required: false
   payload-file-path-parsed:
-    description: 'If payload-file-path is provided instead of json payload, do not replace values in the file from `github.context`.'
+    description: 'Replace templated variables in the JSON payload file with values from the GitHub context and environment variables'
+    default: true
     required: false
-    default: 'false'
   update-ts: # The timestamp of a previous message posted to update it instead of posting a new message
     description: 'The timestamp of a previous message posted. It will update the existing message instead of posting a new message'
     required: false

--- a/test/slack-send-test.js
+++ b/test/slack-send-test.js
@@ -83,10 +83,11 @@ describe('slack-send', () => {
         assert.equal(chatArgs.text, 'who let the dogs out?', 'Correct message provided to postMessage');
       });
 
-      it('should accept a payload-file-path and use it\'s content in the message', async () => {
+      it('should send payload-file-path values with replaced context variables', async () => {
         // Prepare
         fakeCore.getInput.withArgs('channel-id').returns('C123456');
         fakeCore.getInput.withArgs('payload-file-path').returns('./test/resources/valid-payload.json');
+        fakeCore.getBooleanInput.withArgs('payload-file-path-parsed').returns(true);
         fakeGithub.context.actor = 'user123';
 
         // Run
@@ -105,11 +106,12 @@ describe('slack-send', () => {
         assert.equal(chatArgs.oliver, 'benji', 'Correct message provided to postMessage');
         assert.equal(chatArgs.actor, 'user123', 'Correct message provided to postMessage');
       });
-      it('should accept a payload-file-path and use it\'s content in the message without replacing anything', async () => {
+
+      it('should send payload-file-path values without replacing context variables', async () => {
         // Prepare
         fakeCore.getInput.withArgs('channel-id').returns('C123456');
         fakeCore.getInput.withArgs('payload-file-path').returns('./test/resources/valid-payload.json');
-        fakeCore.getInput.withArgs('payload-file-path-parsed').returns('true');
+        fakeCore.getBooleanInput.withArgs('payload-file-path-parsed').returns(false);
         fakeGithub.context.actor = 'user123';
 
         // Run


### PR DESCRIPTION
###  Summary

This PR switches the default value of `payload-file-path-parsed` from `false` to `true` and only replaces variables when this value is `true`.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).